### PR TITLE
Add librabbitmq requirement for PHP Pecl AMQP.

### DIFF
--- a/php/pecl/php-pecl-amqp/php-pecl-amqp.spec
+++ b/php/pecl/php-pecl-amqp/php-pecl-amqp.spec
@@ -40,6 +40,7 @@ BuildRequires: rabbitmq-server
 
 Requires:         %{?scl_prefix}php(zend-abi) = %{php_zend_api}
 Requires:         %{?scl_prefix}php(api) = %{php_core_api}
+Requires:         librabbitmq
 Requires(post):   %{__pecl}
 Requires(postun): %{__pecl}
 


### PR DESCRIPTION
Fixed dependency error:

[root@dev x86_64]# rpm -ivh php-pecl-amqp-1.4.0-1.el6.5.5.x86_64.rpm 
error: Failed dependencies:
    librabbitmq.so.1()(64bit) is needed by phpu-pecl-amqp-1.4.0-1.el6.5.5.x86_64
